### PR TITLE
update scanner's sheet for new EAD structure

### DIFF
--- a/scanners_tsv.xsl
+++ b/scanners_tsv.xsl
@@ -6,21 +6,30 @@
         <xsl:text>&#x9;</xsl:text>
     </xsl:variable>
     <xsl:template match="/">
-        <!-- Level attribute needs changing on a project-dependant basis! -->
-        <xsl:for-each select="//ead:c[@level='file']">
+        <xsl:for-each select="//ead:did/ead:unitid">
+            <xsl:if test="ancestor::ead:c[@level='file'] or ancestor::ead:c[@level='item']" >
             <xsl:choose>
-                <xsl:when test="ead:did/ead:unitid">
-                    <xsl:value-of select="ead:did/ead:unitid"/>
+                <xsl:when test="not(@audience='internal')">
+                    <xsl:value-of select="."/>
                     <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="ead:did/ead:unittitle"/>
+                    <xsl:value-of select="preceding-sibling::ead:unittitle"/>
                     <xsl:value-of select="$varTab"/>
-                    <xsl:text>Box </xsl:text><xsl:value-of select="ead:did/ead:container[@type='box']"/><xsl:text>, Folder </xsl:text><xsl:value-of select="ead:did/ead:container[@type='folder']"/>
+                    <xsl:text>Box </xsl:text><xsl:value-of select="following-sibling::ead:container[@type='box']"/>
+                    <xsl:choose>
+                        <xsl:when test="following-sibling::ead:container[@type='folder']">
+                            <xsl:text>, Folder </xsl:text><xsl:value-of select="following-sibling::ead:container[@type='folder']"/>
+                        </xsl:when>
+                        <xsl:when test="following-sibling::ead:container[@type='volume']">
+                            <xsl:text>, Volume </xsl:text><xsl:value-of select="following-sibling::ead:container[@type='volume']"/>
+                        </xsl:when>
+                    </xsl:choose>
                     <xsl:value-of select="$varTab"/>
-                    <xsl:value-of select="ead:did/ead:unitdate/@normal"/>
+                    <xsl:value-of select="following-sibling::ead:unitdate/@normal"/>
                     <xsl:text>
 </xsl:text>
                 </xsl:when>
             </xsl:choose>
+            </xsl:if>
         </xsl:for-each>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION

### What does this PR do?
Multiple changes to scanner's worksheet XSLT, setting if-statements instead of requiring hardcoded variables to be changed each project, and accommodating changes in the structure of EAD output from ArchivesSpace

### Motivation and context
Some changes are quality of life, others are due to EAD changes in Aspace between 2.7 and 2.8 that  rendered the  sheet  non-functional

### How has this been tested?
Ran t he XSL over  an EAD export from Aspace 2.8.x to verify whether a valid file was produced

### How can a reviewer see the effects of these changes?
When running the previous version of the file over a modern  EAD,  an empty output file will  result.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [X ] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have stakeholder approval to make this change.
